### PR TITLE
Refactor: State Machine

### DIFF
--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -699,7 +699,7 @@ MonoBehaviour:
     m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 0}
     m_SelectOnRight: {fileID: 0}
-  m_Transition: 1
+  m_Transition: 0
   m_Colors:
     m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
     m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
@@ -719,7 +719,7 @@ MonoBehaviour:
     m_PressedTrigger: Pressed
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
-  m_Interactable: 1
+  m_Interactable: 0
   m_TargetGraphic: {fileID: 0}
   m_FillRect: {fileID: 54088573}
   m_HandleRect: {fileID: 0}
@@ -1453,7 +1453,7 @@ MonoBehaviour:
     m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 0}
     m_SelectOnRight: {fileID: 0}
-  m_Transition: 1
+  m_Transition: 0
   m_Colors:
     m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
     m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
@@ -1591,13 +1591,13 @@ MonoBehaviour:
     m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 0}
     m_SelectOnRight: {fileID: 0}
-  m_Transition: 1
+  m_Transition: 0
   m_Colors:
     m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
     m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
     m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
     m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_DisabledColor: {r: 1, g: 1, b: 1, a: 1}
     m_ColorMultiplier: 1
     m_FadeDuration: 0.1
   m_SpriteState:
@@ -1611,7 +1611,7 @@ MonoBehaviour:
     m_PressedTrigger: Pressed
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
-  m_Interactable: 1
+  m_Interactable: 0
   m_TargetGraphic: {fileID: 0}
   m_FillRect: {fileID: 946466724}
   m_HandleRect: {fileID: 0}

--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -119,6 +119,55 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &346749
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 346751}
+  - component: {fileID: 346750}
+  m_Layer: 0
+  m_Name: StateMachine
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &346750
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 346749}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7c62d078afe8e70479664328c710ce24, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  states:
+  - {fileID: 420501587}
+  - {fileID: 1895870144}
+  - {fileID: 2141290624}
+  - {fileID: 1658575598}
+--- !u!4 &346751
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 346749}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1217779786}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &3667136
 GameObject:
   m_ObjectHideFlags: 0
@@ -1014,6 +1063,52 @@ MonoBehaviour:
   m_LightCookieSize: {x: 1, y: 1}
   m_LightCookieOffset: {x: 0, y: 0}
   m_SoftShadowQuality: 1
+--- !u!1 &420501586
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 420501588}
+  - component: {fileID: 420501587}
+  m_Layer: 0
+  m_Name: ForceState
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &420501587
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 420501586}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2c3d6b8e7325cad48844625079ace977, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  forceController: {fileID: 1490453892}
+  throwManager: {fileID: 1832232754}
+--- !u!4 &420501588
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 420501586}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1217779786}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &456111582
 GameObject:
   m_ObjectHideFlags: 0
@@ -2445,6 +2540,42 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1213550376}
   m_CullTransparentMesh: 1
+--- !u!1 &1217779785
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1217779786}
+  m_Layer: 0
+  m_Name: --States--
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1217779786
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1217779785}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 346751}
+  - {fileID: 420501588}
+  - {fileID: 2141290625}
+  - {fileID: 1895870143}
+  - {fileID: 1658575597}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1224683523
 GameObject:
   m_ObjectHideFlags: 0
@@ -2966,6 +3097,51 @@ MonoBehaviour:
   minAngleText: {fileID: 946007981}
   maxAngleText: {fileID: 920471448}
   angleText: {fileID: 1334277005}
+--- !u!1 &1658575596
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1658575597}
+  - component: {fileID: 1658575598}
+  m_Layer: 0
+  m_Name: ReleaseState
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1658575597
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1658575596}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1217779786}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1658575598
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1658575596}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8bb6bd45df24471ca7f42ebf369a1ba1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  throwManager: {fileID: 1832232754}
 --- !u!1 &1685455160
 GameObject:
   m_ObjectHideFlags: 0
@@ -3219,7 +3395,7 @@ GameObject:
   - component: {fileID: 1832232755}
   - component: {fileID: 1832232754}
   m_Layer: 0
-  m_Name: ThrowController
+  m_Name: ThrowManager
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -3237,9 +3413,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1f71af5dfe530b14c86ee2a5b08e618f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  forceController: {fileID: 1490453892}
-  angleController: {fileID: 1648399724}
-  countController: {fileID: 251094149}
+  stateMachine: {fileID: 346750}
   force: 0
   angle: 0
   simulationTimeScale: 1
@@ -3528,6 +3702,51 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1862017156}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &1895870142
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1895870143}
+  - component: {fileID: 1895870144}
+  m_Layer: 0
+  m_Name: CountState
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1895870143
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1895870142}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1217779786}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1895870144
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1895870142}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2a8669a3e85796c4988b0ad13024de61, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  countController: {fileID: 251094149}
 --- !u!1 &1921735681
 GameObject:
   m_ObjectHideFlags: 0
@@ -3975,6 +4194,52 @@ MonoBehaviour:
   distanceText: {fileID: 1685455162}
   throwManager: {fileID: 1832232754}
   boarThrower: {fileID: 198341329}
+--- !u!1 &2141290623
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2141290625}
+  - component: {fileID: 2141290624}
+  m_Layer: 0
+  m_Name: AngleState
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &2141290624
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2141290623}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d2bead42110146848b9223e8e3882b34, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  angleController: {fileID: 1648399724}
+  throwManager: {fileID: 1832232754}
+--- !u!4 &2141290625
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2141290623}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1217779786}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
@@ -3989,3 +4254,4 @@ SceneRoots:
   - {fileID: 1056058343}
   - {fileID: 1853812581}
   - {fileID: 1170002312}
+  - {fileID: 1217779786}

--- a/Assets/Scripts/Gameplay/Debug.meta
+++ b/Assets/Scripts/Gameplay/Debug.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 277bd211a69e168438f16af8cc122137
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Scripts/Gameplay/ThrowStates/AngleState.cs
+++ b/Assets/Scripts/Gameplay/ThrowStates/AngleState.cs
@@ -1,50 +1,57 @@
-public class AngleState : IThrowState
-{
-    public ThrowManager Manager { get; set; }
+using UnityEngine;
 
+public class AngleState : StateBase
+{
+    [SerializeField] private AngleController angleController;
+    [SerializeField] private ThrowManager throwManager;
+    
     private LTDescr pingPongTween;
     private float angle;
 
-    public void OnEnterState(ThrowManager manager)
+    public override void OnEnterState(StateMachine stateMachine)
     {
-        Manager = manager;
-
-        pingPongTween = LeanTween.value(Manager.AngleController.MinAngle, Manager.AngleController.MaxAngle, Manager.AngleController.AnglePingPongTime)
+        base.OnEnterState(stateMachine);
+        
+        pingPongTween = LeanTween.value(angleController.MinAngle, angleController.MaxAngle, angleController.AnglePingPongTime)
             .setOnUpdate(t =>
             {
                 angle = t;
-                manager.AngleController.AngleSlider.value = angle;
+                angleController.AngleSlider.value = angle;
             })
-            .setLoopPingPong(Manager.AngleController.PingPongCount)
+            .setLoopPingPong(angleController.PingPongCount)
             .setOnComplete(Blunder);
     }
 
-    public void OnExitState()
+    public override void OnExitState()
     {
         LeanTween.cancel(pingPongTween.uniqueId);
     }
-
-    public void OnUpdate()
-    {
-    }
     
+    public override void OnClick()
+    {
+        throwManager.Angle = angle;
+
+        LeanTween.cancel(pingPongTween.uniqueId);
+
+        throwManager.NextState();
+    }
+
+    public override void OnReset()
+    {
+        angle = 0;
+        
+        if (pingPongTween != null)
+            LeanTween.cancel(pingPongTween.uniqueId);
+    }
+
     private void Blunder()
     {
         angle = 0;
 
-        Manager.Force /= 2;
+        throwManager.Force /= 2;
         
-        Manager.AngleController.Blunder();
+        angleController.Blunder();
         
         OnClick();
-    }
-
-    public void OnClick()
-    {
-        Manager.Angle = angle;
-
-        LeanTween.cancel(pingPongTween.uniqueId);
-
-        Manager.ChangeState(new ReleaseState());
     }
 }

--- a/Assets/Scripts/Gameplay/ThrowStates/CountState.cs
+++ b/Assets/Scripts/Gameplay/ThrowStates/CountState.cs
@@ -1,45 +1,34 @@
 using Cysharp.Threading.Tasks;
+using UnityEngine;
 
-public class CountState : IThrowState
+public class CountState : StateBase
 {
-    public ThrowManager Manager { get; set; }
-
-    public void OnEnterState(ThrowManager manager)
+    [SerializeField] private CountController countController;
+    
+    public override void OnEnterState(StateMachine stateMachine)
     {
-        Manager = manager;
-
-        Manager.CountController.Open();
+        base.OnEnterState(stateMachine);
+        
+        countController.Open();
 
         CountDown().Forget();
     }
-
-    public void OnExitState()
-    {
-    }
-
-    public void OnUpdate()
-    {
-    }
-
-    public void OnClick()
-    {
-    }
-
+    
     private async UniTaskVoid CountDown()
     {
-        int count = Manager.CountController.Count;
+        int count = countController.Count;
 
         while (count > 0)
         {
-            Manager.CountController.CountText.text = count.ToString();
+            countController.CountText.text = count.ToString();
 
             await UniTask.Delay(1000);
-            
+
             count--;
         }
 
-        Manager.CountController.Close();
+        countController.Close();
 
-        Manager.ChangeState(new AngleState());
+        StateMachine.NextState();
     }
 }

--- a/Assets/Scripts/Gameplay/ThrowStates/IThrowState.cs
+++ b/Assets/Scripts/Gameplay/ThrowStates/IThrowState.cs
@@ -1,9 +1,0 @@
-public interface IThrowState
-{
-    public ThrowManager Manager { get; set; }
-    
-    public void OnEnterState(ThrowManager manager);
-    public void OnExitState();
-    public void OnUpdate();
-    public void OnClick();
-}

--- a/Assets/Scripts/Gameplay/ThrowStates/IThrowState.cs.meta
+++ b/Assets/Scripts/Gameplay/ThrowStates/IThrowState.cs.meta
@@ -1,2 +1,0 @@
-fileFormatVersion: 2
-guid: 7d30dc81ca68ec94b8564312362b026e

--- a/Assets/Scripts/Gameplay/ThrowStates/ReleaseState.cs
+++ b/Assets/Scripts/Gameplay/ThrowStates/ReleaseState.cs
@@ -1,21 +1,13 @@
-public class ReleaseState : IThrowState
+using UnityEngine;
+
+public class ReleaseState : StateBase
 {
-    public ThrowManager Manager { get; set; }
+    [SerializeField] private ThrowManager throwManager;
     
-    public void OnEnterState(ThrowManager manager)
+    public override void OnEnterState(StateMachine stateMachine)
     {
-        manager.Release();
-    }
-
-    public void OnExitState()
-    {
-    }
-
-    public void OnUpdate()
-    {
-    }
-
-    public void OnClick()
-    {
+        base.OnEnterState(stateMachine);
+        
+        throwManager.Release();
     }
 }

--- a/Assets/Scripts/Gameplay/ThrowStates/StateBase.cs
+++ b/Assets/Scripts/Gameplay/ThrowStates/StateBase.cs
@@ -1,0 +1,27 @@
+using UnityEngine;
+
+public abstract class StateBase : MonoBehaviour
+{
+    protected StateMachine StateMachine { get; private set; }
+    
+    public virtual void OnEnterState(StateMachine stateMachine)
+    {
+        StateMachine = stateMachine;
+    }
+
+    public virtual void OnExitState()
+    {
+    }
+
+    public virtual void OnUpdate()
+    {
+    }
+
+    public virtual void OnClick()
+    {
+    }
+
+    public virtual void OnReset()
+    {
+    }
+}

--- a/Assets/Scripts/Gameplay/ThrowStates/StateBase.cs.meta
+++ b/Assets/Scripts/Gameplay/ThrowStates/StateBase.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: c79fc8ec0ba54af1af07bf3bdfbf7863
+timeCreated: 1733319724

--- a/Assets/Scripts/Gameplay/ThrowStates/StateMachine.cs
+++ b/Assets/Scripts/Gameplay/ThrowStates/StateMachine.cs
@@ -1,0 +1,43 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+public class StateMachine : MonoBehaviour
+{
+    [SerializeField] private List<StateBase> states = new();
+   
+    private StateBase currentState;
+    
+    public void OnClick()
+    {
+        currentState.OnClick();
+    }
+
+    private void Update()
+    {
+        currentState?.OnUpdate();
+    }
+
+    public void ChangeState(StateBase newState)
+    {
+        currentState?.OnExitState();
+        currentState = newState;
+        currentState.OnEnterState(this);
+    }
+    
+    public void NextState()
+    {
+        if (currentState == states[^1])
+            return;
+        
+        ChangeState(states[states.IndexOf(currentState) + 1]);
+    }
+
+    public void OnReset()
+    {
+        foreach (StateBase state in states)
+            state.OnReset();
+        
+        if (states.Count > 0)
+            ChangeState(states[0]);
+    }
+}

--- a/Assets/Scripts/Gameplay/ThrowStates/StateMachine.cs.meta
+++ b/Assets/Scripts/Gameplay/ThrowStates/StateMachine.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7c62d078afe8e70479664328c710ce24

--- a/Assets/Scripts/Gameplay/ThrowStates/ThrowManager.cs
+++ b/Assets/Scripts/Gameplay/ThrowStates/ThrowManager.cs
@@ -3,21 +3,13 @@ using UnityEngine;
 
 public class ThrowManager : MonoBehaviour
 {
-    [SerializeField] private ForceController forceController;
-    [SerializeField] private AngleController angleController;
-    [SerializeField] private CountController countController;
+    [SerializeField] private StateMachine stateMachine;
     
     [Header("Debug")] 
     [SerializeField] private float force;
     [SerializeField] private float angle;
     [SerializeField] private float simulationTimeScale = 1.0f;
-
-    private IThrowState currentState;
-
-    public ForceController ForceController => forceController;
-    public AngleController AngleController => angleController;
-    public CountController CountController => countController;
-
+    
     public float Force { get => force; set => force = value; }
     public float Angle { get => angle; set => angle = value; }
 
@@ -41,26 +33,19 @@ public class ThrowManager : MonoBehaviour
 
     private void OnClick()
     {
-        currentState.OnClick();
+        stateMachine.OnClick();
     }
 
-    private void Update()
+    public void NextState()
     {
-        currentState?.OnUpdate();
-    }
-
-    public void ChangeState(IThrowState newState)
-    {
-        currentState?.OnExitState();
-        currentState = newState;
-        currentState.OnEnterState(this);
+        stateMachine.NextState();
     }
 
     public void ResetThrow()
     {
         OnReset?.Invoke();
 
-        ChangeState(new ForceState());
+        stateMachine.OnReset();
         
         // Debug
         Time.timeScale = 1;


### PR DESCRIPTION
States that previously were instantiated in code now are GameObjects with references to their Controllers
![image](https://github.com/user-attachments/assets/a770c62f-fa75-4cde-a848-43d073297bfe)

ThrowManager now only has one reference to the state machine instead of references to all controllers
![image](https://github.com/user-attachments/assets/f06a1e7b-d730-45af-9349-1d874e33b942)
